### PR TITLE
WIP - Don't throw exception if the required Mage version is not declared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/MagentoComposer.php
+++ b/MagentoComposer.php
@@ -2,11 +2,12 @@
 
 namespace Inviqa;
 
-use Composer\Script\PackageEvent;
+use Composer\Composer;
+use Composer\Installer\PackageEvent;
 use Composer\DependencyResolver\SolverProblemsException;
-use Composer\DependencyResolver\Problem;
 use Composer\DependencyResolver\Pool;
-use Composer\Package\Package;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionParser;
 
 /**
@@ -16,31 +17,91 @@ class MagentoComposer
 {
     const PACKAGE_TYPE_MAGENTO = 'magento-module';
 
+    const CONFIG_ROOT_STRICT = 'strict-check';
+
     // @codingStandardsIgnoreStart
     const MESSAGE_WRONG_MAGENTO_ROOT = 'Mage class not found in path %s. Please specify the correct "magento-root-dir" value in extra section!';
     const MESSAGE_EMPTY_MAGENTO_ROOT = 'The key "magento-root-dir" is missing from extra configuration section.';
-    const MESSAGE_EMPTY_EXPECTED_VERSION = "The module doesn't support magento %s edition or the '%s' is missing from the module's configuration.";
-    const MESSAGE_VERSON_MISMATCH = "Magento %s could not be found! Current Magento version is %s.";
+    const MESSAGE_EMPTY_EXPECTED_VERSION = "The %s module doesn't support Magento %s edition or the '%s' is missing from the module's configuration.";
+    const MESSAGE_VERSION_MISMATCH = "Magento %s could not be found! Current Magento version is %s.";
     // @codingStandardsIgnoreEnd
 
-    public static function checkVersion(PackageEvent $event)
-    {
-        $self = new self;
-        $rootExtra = $event->getComposer()->getPackage()->getExtra();
-        $packageExtra = $event->getOperation()->getPackage()->getExtra();
+    /**
+     * @var Composer
+     */
+    private $composer;
 
-        if (!$self->isMagentoRequired($event->getOperation()->getPackage())) {
+    /**
+     * @var IOInterface
+     */
+    private $io;
+
+    /**
+     * @var PackageEvent
+     */
+    private $event;
+
+    public function __construct(Composer $composer, IOInterface $io, PackageEvent $event)
+    {
+        $this->composer = $composer;
+        $this->io = $io;
+        $this->event = $event;
+    }
+
+    /**
+     * @return PackageInterface
+     */
+    private function getModuleToBeInstalled()
+    {
+        return $this->event->getOperation()->getPackage();
+    }
+
+    /**
+     * @return PackageInterface
+     */
+    private function getRootPackage()
+    {
+        return $this->event->getComposer()->getPackage();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isStrictCheck()
+    {
+        $rootExtra = $this->getRootPackage()->getExtra();
+
+        // disable strict check by default
+        if (empty($rootExtra[self::CONFIG_ROOT_STRICT])) {
+            return false;
+        }
+        return (bool) $rootExtra[self::CONFIG_ROOT_STRICT];
+    }
+
+    public function checkVersion()
+    {
+        $rootExtra = $this->getRootPackage()->getExtra();
+        $packageExtra = $this->getModuleToBeInstalled()->getExtra();
+
+        if (!$this->isMagentoRequired($this->getModuleToBeInstalled())) {
             return;
         }
 
-        $self->loadMage($rootExtra);
-        $expectedVersionConstraint = $self->getExpectedMagentoVersion($packageExtra);
-        $currentVersionConstraint = $self->getCurrentMagentoVersion($rootExtra);
+        $this->loadMage($rootExtra);
+
+        $expectedVersionConstraint = $this->getExpectedMagentoVersion($packageExtra);
+
+        // some error happened
+        if ($expectedVersionConstraint === false) {
+            return;
+        }
+
+        $currentVersionConstraint = $this->getCurrentMagentoVersion($rootExtra);
 
         if (!$currentVersionConstraint->matches($expectedVersionConstraint)) {
-            throw $self->createException(
+            throw $this->createException(
                 sprintf(
-                    self::MESSAGE_VERSON_MISMATCH,
+                    self::MESSAGE_VERSION_MISMATCH,
                     $expectedVersionConstraint->getPrettyString(),
                     $currentVersionConstraint->getPrettyString()
                 )
@@ -48,7 +109,7 @@ class MagentoComposer
         }
     }
 
-    private function isMagentoRequired(Package $package)
+    private function isMagentoRequired(PackageInterface $package)
     {
         return $package->getType() == self::PACKAGE_TYPE_MAGENTO;
     }
@@ -81,7 +142,14 @@ class MagentoComposer
         $versionConfigKey = $this->getVersionConfigKey($edition);
 
         if (empty($versionConfigKey) || empty($extra[$versionConfigKey])) {
-            throw $this->createException(sprintf(self::MESSAGE_EMPTY_EXPECTED_VERSION, $edition, $versionConfigKey));
+            $moduleName = $this->getModuleToBeInstalled()->getName();
+            $errMsg = sprintf(self::MESSAGE_EMPTY_EXPECTED_VERSION, $moduleName, $edition, $versionConfigKey);
+            if ($this->isStrictCheck()) {
+                throw $this->createException($errMsg);
+            } else {
+                $this->io->writeError("<warning>$errMsg</warning>");
+                return false;
+            }
         }
 
         $versionParser = new VersionParser();

--- a/Plugin.php
+++ b/Plugin.php
@@ -6,8 +6,8 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\Script\ScriptEvents;
-use Composer\Script\PackageEvent;
+use Composer\Installer\PackageEvents;
+use Composer\Installer\PackageEvent;
 
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
@@ -17,43 +17,33 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     protected $composer;
 
     /**
-     * Apply plugin modifications to composer
-     *
+     * @var IOInterface
+     */
+    protected $io;
+
+    /**
      * @param Composer    $composer
      * @param IOInterface $io
      */
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
+        $this->io = $io;
     }
 
     /**
-     * Returns an array of event names this subscriber wants to listen to.
-     *
-     * The array keys are event names and the value can be:
-     *
-     * * The method name to call (priority defaults to 0)
-     * * An array composed of the method name to call and the priority
-     * * An array of arrays composed of the method names to call and respective
-     *   priorities, or 0 if unset
-     *
-     * For instance:
-     *
-     * * array('eventName' => 'methodName')
-     * * array('eventName' => array('methodName', $priority))
-     * * array('eventName' => array(array('methodName1', $priority), array('methodName2'))
-     *
-     * @return array The event names to listen to
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
         return array(
-            ScriptEvents::PRE_PACKAGE_INSTALL => array('onPreInstallPackage', 0),
+            PackageEvents::PRE_PACKAGE_INSTALL => array('onPreInstallPackage', 0),
         );
     }
 
     public function onPreInstallPackage(PackageEvent $event)
     {
-        MagentoComposer::checkVersion($event);
+        $checker = new MagentoComposer($this->composer, $this->io, $event);
+        $checker->checkVersion();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "proprietary",
     "description": "Ensures that a Magento module has the expected Magento version installed.",
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0"
     },
     "require-dev": {
         "composer/composer": "^1.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "composer-plugin-api": "1.0.0"
     },
+    "require-dev": {
+        "composer/composer": "^1.0@dev"
+    },
     "autoload": {
         "psr-4": {
             "Inviqa\\": ""


### PR DESCRIPTION
Most of the firegento packages don't declared the `magento-version-(ee|ce)` config.
This means that this plugin would throw an exception on most - if not all - said packages.

A new boolean config flag was introduced - `strict-check` - which is `false` by default. If `false`, the plugin will only show a warning, instead of throwing an exception and stopping the install process.

I haven't tested this yet. Reviews welcomed.